### PR TITLE
Implement tuner gain setters/getters

### DIFF
--- a/src/RTLSDR.jl
+++ b/src/RTLSDR.jl
@@ -15,6 +15,8 @@ export
     set_rate,
     get_freq,
     set_freq,
+    get_gain,
+    set_gain,
     set_agc_mode,
     set_tuner_gain_mode
 
@@ -71,6 +73,24 @@ function get_freq(r::RtlSdr)
     @assert r.valid_ptr
     freq = rtlsdr_get_center_freq(r.dongle_ptr)
     return Int(freq)
+end
+
+"""
+`set_gain(r::RtlSdr, gain_db)`
+
+Interface for `rtlsdr_set_tuner_gain`.
+"""
+function set_gain(r::RtlSdr, gain_db)
+    @assert r.valid_ptr
+    # TODO: Get valid tuner gains from librtlsdr and round user input
+    # For r82xx, librtlsdr steps through gains in predetermined
+    # steps until tuner gain >= setpoint. Works, but doesn't give what    # user might expect.
+    rtlsdr_set_tuner_gain(r.dongle_ptr, gain_db)
+end
+function get_gain(r::RtlSdr)
+    @assert r.valid_ptr
+    gain = rtlsdr_get_tuner_gain(r.dongle_ptr)
+    return gain
 end
 
 """

--- a/src/RTLSDR.jl
+++ b/src/RTLSDR.jl
@@ -27,8 +27,8 @@ mutable struct RtlSdr
     valid_ptr::Bool
     dongle_ptr::Ptr{rtlsdr_dev}
 
-    function RtlSdr()
-        dp = rtlsdr_open()
+    function RtlSdr(index::Int64=0)
+        dp = rtlsdr_open(index)
 
         r = new(true, dp)
 

--- a/src/c_interface.jl
+++ b/src/c_interface.jl
@@ -114,15 +114,12 @@ function rtlsdr_set_tuner_gain(rf::Ref{rtlsdr_dev}, gain)
 end
 
 function rtlsdr_get_tuner_gain(rf::Ref{rtlsdr_dev})
-    gain = Array{Cint,1}(undef,1)
-    ret = ccall( (:rtlsdr_get_tuner_gain, "librtlsdr"),
+    gain = ccall( (:rtlsdr_get_tuner_gain, "librtlsdr"),
                  Cint,
-                 (Ref{rtlsdr_dev},Ptr{Cint}),
-                 rf,
-                 gain
+                 (Ref{rtlsdr_dev},),
+                 rf
                )
-    if ret != 0; throw(RTLSDRError("RTLSDR.jl reports: Error getting tuner gain (error code $ret).")); end
-    return gain[1]
+    return gain
 end
 
 

--- a/src/c_interface.jl
+++ b/src/c_interface.jl
@@ -11,8 +11,7 @@ mutable struct RTLSDRError <: Exception
 end
 
 # returns a pointer to 
-function rtlsdr_open()
-    index = 0
+function rtlsdr_open(index::Int64=0)
     rd = Array{Ptr{rtlsdr_dev},1}(undef,1)
     ret = ccall( (:rtlsdr_open, "librtlsdr"),
                  Cint,


### PR DESCRIPTION
I have ported functions for setting and querying tuner gain from roger-'s pyrtlsdr. The set function checks the input gain in dB against the tuner's available settings in tenths of a dB and chooses the nearest one. This is my first bit of Julia code, so constructive criticism is welcome.